### PR TITLE
10주차 과제 제출합니다.

### DIFF
--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/product/ProductFacade.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/product/ProductFacade.kt
@@ -8,6 +8,7 @@ import com.loopers.application.product.command.GetProductsResult
 import com.loopers.domain.brand.BrandService
 import com.loopers.domain.product.ProductRankings
 import com.loopers.domain.product.ProductService
+import com.loopers.domain.product.RankingPeriod
 import com.loopers.domain.product.params.GetProductRankingParam
 import org.springframework.stereotype.Component
 import java.time.LocalDate
@@ -31,18 +32,43 @@ class ProductFacade(
         )
     }
 
-    fun getProductRanking(command: GetProductRankingCommand): GetProductRankingResult {
+    fun getProductRankings(command: GetProductRankingCommand): GetProductRankingResult {
+        val productRankings = when (command.period) {
+            RankingPeriod.DAILY -> getDailyRankings(command)
+            RankingPeriod.WEEKLY -> getWeeklyRankings(command)
+            RankingPeriod.MONTHLY -> getMonthlyRankings(command)
+        }
+
+        return productRankings.toResult()
+    }
+
+    private fun getDailyRankings(command: GetProductRankingCommand): ProductRankings {
         val param = GetProductRankingParam(
             page = command.pageable.pageNumber,
             perPage = command.pageable.pageSize,
             date = command.date,
         )
-        val rankings = productService.getProductRanking(param)
 
-        val productIds = rankings.rankings.map(ProductRankings.ProductRanking::productId)
+        return productService.getProductRanking(param)
+    }
+
+    private fun getWeeklyRankings(command: GetProductRankingCommand): ProductRankings = productService.getWeeklyProductRanking(
+        command.date,
+        command.pageable.pageNumber,
+        command.pageable.pageSize,
+    )
+
+    private fun getMonthlyRankings(command: GetProductRankingCommand): ProductRankings = productService.getMonthlyProductRanking(
+        command.date,
+        command.pageable.pageNumber,
+        command.pageable.pageSize,
+    )
+
+    private fun ProductRankings.toResult(): GetProductRankingResult {
+        val productIds = rankings.map(ProductRankings.ProductRanking::productId)
         val products = productService.findAllByIds(productIds)
 
-        val rankedProducts = rankings.rankings.mapNotNull { ranking ->
+        val rankedProducts = rankings.mapNotNull { ranking ->
             val product = products.find { it.id == ranking.productId }
             product?.let {
                 GetProductRankingResult.RankedProduct(
@@ -55,6 +81,6 @@ class ProductFacade(
             }
         }
 
-        return GetProductRankingResult(rankedProducts, rankings)
+        return GetProductRankingResult(rankedProducts, this)
     }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/application/product/command/GetProductRankingCommand.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/application/product/command/GetProductRankingCommand.kt
@@ -1,9 +1,11 @@
 package com.loopers.application.product.command
 
+import com.loopers.domain.product.RankingPeriod
 import org.springframework.data.domain.Pageable
 import java.time.LocalDate
 
 data class GetProductRankingCommand(
     val pageable: Pageable,
     val date: LocalDate = LocalDate.now(),
+    val period: RankingPeriod = RankingPeriod.DAILY,
 )

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/RankingPeriod.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/RankingPeriod.kt
@@ -1,0 +1,5 @@
+package com.loopers.domain.product
+
+enum class RankingPeriod {
+    DAILY, WEEKLY, MONTHLY
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankMonthly.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankMonthly.kt
@@ -1,0 +1,15 @@
+package com.loopers.domain.product.mv
+
+import com.loopers.domain.BaseEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "mv_product_rank_monthly")
+class MvProductRankMonthly(
+    val productId: Long,
+    val productName: String,
+    val brandId: Long,
+    val likeCount: Long,
+    val rank: Long,
+) : BaseEntity()

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankMonthlyRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankMonthlyRepository.kt
@@ -1,0 +1,18 @@
+package com.loopers.domain.product.mv
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import java.time.ZonedDateTime
+
+interface MvProductRankMonthlyRepository {
+    fun findByCreatedAtBetween(
+        startDateTime: ZonedDateTime,
+        endDateTime: ZonedDateTime,
+        pageable: Pageable
+    ): Page<MvProductRankMonthly>
+    
+    fun countByCreatedAtBetween(
+        startDateTime: ZonedDateTime,
+        endDateTime: ZonedDateTime
+    ): Long
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankWeekly.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankWeekly.kt
@@ -1,0 +1,15 @@
+package com.loopers.domain.product.mv
+
+import com.loopers.domain.BaseEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "mv_product_rank_weekly")
+class MvProductRankWeekly(
+    val productId: Long,
+    val productName: String,
+    val brandId: Long,
+    val likeCount: Long,
+    val rank: Long,
+) : BaseEntity()

--- a/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankWeeklyRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankWeeklyRepository.kt
@@ -1,0 +1,18 @@
+package com.loopers.domain.product.mv
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import java.time.ZonedDateTime
+
+interface MvProductRankWeeklyRepository {
+    fun findByCreatedAtBetween(
+        startDateTime: ZonedDateTime,
+        endDateTime: ZonedDateTime,
+        pageable: Pageable
+    ): Page<MvProductRankWeekly>
+    
+    fun countByCreatedAtBetween(
+        startDateTime: ZonedDateTime,
+        endDateTime: ZonedDateTime
+    ): Long
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/mv/JpaMvProductRankMonthlyRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/mv/JpaMvProductRankMonthlyRepository.kt
@@ -1,0 +1,20 @@
+package com.loopers.infrastructure.product.mv
+
+import com.loopers.domain.product.mv.MvProductRankMonthly
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.ZonedDateTime
+
+interface JpaMvProductRankMonthlyRepository : JpaRepository<MvProductRankMonthly, Long> {
+    fun findByCreatedAtBetween(
+        startDateTime: ZonedDateTime,
+        endDateTime: ZonedDateTime,
+        pageable: Pageable
+    ): Page<MvProductRankMonthly>
+    
+    fun countByCreatedAtBetween(
+        startDateTime: ZonedDateTime,
+        endDateTime: ZonedDateTime
+    ): Long
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/mv/JpaMvProductRankWeeklyRepository.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/mv/JpaMvProductRankWeeklyRepository.kt
@@ -1,0 +1,20 @@
+package com.loopers.infrastructure.product.mv
+
+import com.loopers.domain.product.mv.MvProductRankWeekly
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.ZonedDateTime
+
+interface JpaMvProductRankWeeklyRepository : JpaRepository<MvProductRankWeekly, Long> {
+    fun findByCreatedAtBetween(
+        startDateTime: ZonedDateTime,
+        endDateTime: ZonedDateTime,
+        pageable: Pageable
+    ): Page<MvProductRankWeekly>
+    
+    fun countByCreatedAtBetween(
+        startDateTime: ZonedDateTime,
+        endDateTime: ZonedDateTime
+    ): Long
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/mv/MvProductRankMonthlyRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/mv/MvProductRankMonthlyRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package com.loopers.infrastructure.product.mv
+
+import com.loopers.domain.product.mv.MvProductRankMonthly
+import com.loopers.domain.product.mv.MvProductRankMonthlyRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+import java.time.ZonedDateTime
+
+@Repository
+class MvProductRankMonthlyRepositoryImpl(
+    private val jpaMvProductRankMonthlyRepository: JpaMvProductRankMonthlyRepository
+) : MvProductRankMonthlyRepository {
+    
+    override fun findByCreatedAtBetween(
+        startDateTime: ZonedDateTime,
+        endDateTime: ZonedDateTime,
+        pageable: Pageable
+    ): Page<MvProductRankMonthly> {
+        return jpaMvProductRankMonthlyRepository.findByCreatedAtBetween(startDateTime, endDateTime, pageable)
+    }
+    
+    override fun countByCreatedAtBetween(
+        startDateTime: ZonedDateTime,
+        endDateTime: ZonedDateTime
+    ): Long {
+        return jpaMvProductRankMonthlyRepository.countByCreatedAtBetween(startDateTime, endDateTime)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/mv/MvProductRankWeeklyRepositoryImpl.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/infrastructure/product/mv/MvProductRankWeeklyRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package com.loopers.infrastructure.product.mv
+
+import com.loopers.domain.product.mv.MvProductRankWeekly
+import com.loopers.domain.product.mv.MvProductRankWeeklyRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+import java.time.ZonedDateTime
+
+@Repository
+class MvProductRankWeeklyRepositoryImpl(
+    private val jpaMvProductRankWeeklyRepository: JpaMvProductRankWeeklyRepository
+) : MvProductRankWeeklyRepository {
+    
+    override fun findByCreatedAtBetween(
+        startDateTime: ZonedDateTime,
+        endDateTime: ZonedDateTime,
+        pageable: Pageable
+    ): Page<MvProductRankWeekly> {
+        return jpaMvProductRankWeeklyRepository.findByCreatedAtBetween(startDateTime, endDateTime, pageable)
+    }
+    
+    override fun countByCreatedAtBetween(
+        startDateTime: ZonedDateTime,
+        endDateTime: ZonedDateTime
+    ): Long {
+        return jpaMvProductRankWeeklyRepository.countByCreatedAtBetween(startDateTime, endDateTime)
+    }
+}

--- a/apps/commerce-api/src/main/kotlin/com/loopers/presentation/product/ProductV1Controller.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/presentation/product/ProductV1Controller.kt
@@ -30,7 +30,7 @@ class ProductV1Controller(
 
     @GetMapping("/api/v1/products/rankings")
     fun getProductRanking(request: GetProductRankingRequest): ApiResponse<GetProductRankingResponse> {
-        val result = productFacade.getProductRanking(request.toCommand())
+        val result = productFacade.getProductRankings(request.toCommand())
         return ApiResponse.success(GetProductRankingResponse(result))
     }
 }

--- a/apps/commerce-api/src/main/kotlin/com/loopers/presentation/product/dto/GetProductRankingRequest.kt
+++ b/apps/commerce-api/src/main/kotlin/com/loopers/presentation/product/dto/GetProductRankingRequest.kt
@@ -1,6 +1,7 @@
 package com.loopers.presentation.product.dto
 
 import com.loopers.application.product.command.GetProductRankingCommand
+import com.loopers.domain.product.RankingPeriod
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.format.annotation.DateTimeFormat
@@ -11,9 +12,11 @@ data class GetProductRankingRequest(
     val size: Int = 20,
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     val date: LocalDate = LocalDate.now(),
+    val period: RankingPeriod = RankingPeriod.DAILY,
 ) {
     fun toCommand(): GetProductRankingCommand = GetProductRankingCommand(
         pageable = PageRequest.of(page, size),
-        date = date
+        date = date,
+        period = period
     )
 }

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/product/ProductServiceImplTest.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/product/ProductServiceImplTest.kt
@@ -2,6 +2,8 @@ package com.loopers.domain.product
 
 import com.loopers.cache.SortedCacheRepository
 import com.loopers.domain.product.cache.ProductCacheKeys
+import com.loopers.domain.product.mv.MvProductRankWeeklyRepository
+import com.loopers.domain.product.mv.MvProductRankMonthlyRepository
 import com.loopers.domain.product.params.DeductProductItemsQuantityParam
 import com.loopers.domain.product.params.GetProductParam
 import com.loopers.domain.product.vo.LikeCount
@@ -34,7 +36,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             val param = GetProductParam(null, null, 0, 10)
 
@@ -51,7 +55,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             val product1 = ProductFixture.`활성 상품 1`.toEntity()
             val product2 = ProductFixture.`활성 상품 2`.toEntity()
@@ -78,7 +84,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             // DB에 데이터 저장
             val dbProduct = ProductFixture.create(name = "DB상품")
@@ -110,7 +118,9 @@ class ProductServiceImplTest {
             val testCacheRepository = TestCacheRepository()
             val cacheRepository = spyk(testCacheRepository)
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             val product = ProductFixture.기본.toEntity()
             productRepository.save(product)
@@ -135,7 +145,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             val product = ProductFixture.`활성 상품 1`.toEntity()
             val savedProduct = productRepository.save(product)
@@ -153,7 +165,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             val nonExistentId = 999L
 
@@ -178,7 +192,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             val product = ProductFixture.`활성 상품 1`.toEntity()
             val savedProduct = productRepository.save(product)
@@ -211,7 +227,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             val product = ProductFixture.`활성 상품 1`.toEntity()
             val savedProduct = productRepository.save(product)
@@ -231,7 +249,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             val product = ProductFixture.`활성 상품 1`.toEntity()
             val savedProduct = productRepository.save(product)
@@ -255,7 +275,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             val product = ProductFixture.`활성 상품 1`.toEntity()
             val savedProduct = productRepository.save(product)
@@ -285,7 +307,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             val product = ProductFixture.`활성 상품 1`.toEntity()
             val savedProduct = productRepository.save(product)
@@ -316,7 +340,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             val param = DeductProductItemsQuantityParam(
                 items = listOf(
@@ -341,7 +367,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             val product = ProductFixture.`활성 상품 1`.toEntity()
             val savedProduct = productRepository.save(product)
@@ -378,7 +406,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             // when then
             assertThatThrownBy {
@@ -394,7 +424,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             val product = ProductFixture.`활성 상품 1`.toEntity()
             val savedProduct = productRepository.save(product)
@@ -416,7 +448,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             // when then
             assertThatThrownBy {
@@ -432,7 +466,9 @@ class ProductServiceImplTest {
             val productRepository = TestProductRepository()
             val cacheRepository = TestCacheRepository()
             val sortedCacheRepository = mockk<SortedCacheRepository>()
-            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository)
+            val mvProductRankWeeklyRepository = mockk<MvProductRankWeeklyRepository>()
+            val mvProductRankMonthlyRepository = mockk<MvProductRankMonthlyRepository>()
+            val cut = ProductServiceImpl(productRepository, cacheRepository, sortedCacheRepository, mvProductRankWeeklyRepository, mvProductRankMonthlyRepository)
 
             val product = ProductFixture.`활성 상품 1`.toEntity()
             product.increaseLikeCount()

--- a/apps/commerce-api/src/test/kotlin/com/loopers/domain/product/fake/TestProductService.kt
+++ b/apps/commerce-api/src/test/kotlin/com/loopers/domain/product/fake/TestProductService.kt
@@ -134,4 +134,22 @@ class TestProductService : ProductService {
     override fun getProductRank(productId: Long, date: LocalDate): Long? {
         return null
     }
+
+    override fun getWeeklyProductRanking(date: LocalDate, page: Int, size: Int): ProductRankings {
+        return ProductRankings(
+            rankings = emptyList(),
+            totalCount = 0,
+            page = page,
+            perPage = size
+        )
+    }
+
+    override fun getMonthlyProductRanking(date: LocalDate, page: Int, size: Int): ProductRankings {
+        return ProductRankings(
+            rankings = emptyList(),
+            totalCount = 0,
+            page = page,
+            perPage = size
+        )
+    }
 }

--- a/apps/commerce-batch/build.gradle.kts
+++ b/apps/commerce-batch/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    id("org.jetbrains.kotlin.plugin.jpa")
+}
+
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":supports:jackson"))
+
+    // Spring Batch
+    implementation("org.springframework.boot:spring-boot-starter-batch")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/CommerceBatchApplication.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/CommerceBatchApplication.kt
@@ -1,0 +1,22 @@
+package com.loopers
+
+import jakarta.annotation.PostConstruct
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+import java.util.TimeZone
+
+@ConfigurationPropertiesScan
+@SpringBootApplication
+class CommerceBatchApplication {
+
+    @PostConstruct
+    fun started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
+    }
+}
+
+fun main(args: Array<String>) {
+    runApplication<CommerceBatchApplication>(*args)
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/application/product/MvProductMonthlyJob.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/application/product/MvProductMonthlyJob.kt
@@ -1,0 +1,74 @@
+package com.loopers.application.product
+
+import com.loopers.domain.product.ProductMetrics
+import com.loopers.domain.product.ProductMetricsRepository
+import com.loopers.domain.product.mv.MvProductRankMonthly
+import com.loopers.domain.product.mv.MvProductRankMonthlyRepository
+import org.springframework.batch.core.Job
+import org.springframework.batch.core.Step
+import org.springframework.batch.core.job.builder.JobBuilder
+import org.springframework.batch.core.launch.support.RunIdIncrementer
+import org.springframework.batch.core.repository.JobRepository
+import org.springframework.batch.core.step.builder.StepBuilder
+import org.springframework.batch.item.ItemProcessor
+import org.springframework.batch.item.ItemWriter
+import org.springframework.batch.item.support.ListItemReader
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.transaction.PlatformTransactionManager
+import java.time.LocalDate
+
+@Configuration
+class MvProductMonthlyJob(
+    private val jobRepository: JobRepository,
+    private val transactionManager: PlatformTransactionManager,
+    private val productMetricsRepository: ProductMetricsRepository,
+    private val mvProductRankMonthlyRepository: MvProductRankMonthlyRepository,
+) {
+
+    @Bean
+    fun monthlyRankingJob(): Job {
+        return JobBuilder("monthlyRankingJob", jobRepository)
+            .incrementer(RunIdIncrementer())
+            .start(monthlyStep())
+            .build()
+    }
+
+    @Bean
+    fun monthlyStep(): Step {
+        return StepBuilder("monthlyStep", jobRepository)
+            .chunk<ProductMetrics, MvProductRankMonthly>(10, transactionManager)
+            .reader(monthlyProductReader())
+            .processor(monthlyProcessor())
+            .writer(monthlyWriter())
+            .build()
+    }
+
+    @Bean
+    fun monthlyProductReader(): ListItemReader<ProductMetrics> {
+        val today = LocalDate.now()
+        val monthStart = today.withDayOfMonth(1)
+
+        val productMetrics = productMetricsRepository.findByMetricDateBetweenOrderByRankAscLimit(monthStart, today, 100)
+
+        return ListItemReader(productMetrics)
+    }
+
+    @Bean
+    fun monthlyProcessor(): ItemProcessor<ProductMetrics, MvProductRankMonthly> = ItemProcessor { productMetrics ->
+        MvProductRankMonthly(
+            productId = productMetrics.productId,
+            productName = productMetrics.productName,
+            brandId = productMetrics.brandId,
+            likeCount = productMetrics.likeCount,
+            rank = productMetrics.rank,
+        )
+    }
+
+    @Bean
+    fun monthlyWriter(): ItemWriter<MvProductRankMonthly> {
+        return ItemWriter { items ->
+            mvProductRankMonthlyRepository.saveAll(items.toList())
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/application/product/MvProductWeeklyJob.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/application/product/MvProductWeeklyJob.kt
@@ -1,0 +1,74 @@
+package com.loopers.application.product
+
+import com.loopers.domain.product.ProductMetrics
+import com.loopers.domain.product.ProductMetricsRepository
+import com.loopers.domain.product.mv.MvProductRankWeekly
+import com.loopers.domain.product.mv.MvProductRankWeeklyRepository
+import org.springframework.batch.core.Job
+import org.springframework.batch.core.Step
+import org.springframework.batch.core.job.builder.JobBuilder
+import org.springframework.batch.core.launch.support.RunIdIncrementer
+import org.springframework.batch.core.repository.JobRepository
+import org.springframework.batch.core.step.builder.StepBuilder
+import org.springframework.batch.item.ItemProcessor
+import org.springframework.batch.item.ItemWriter
+import org.springframework.batch.item.support.ListItemReader
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.transaction.PlatformTransactionManager
+import java.time.LocalDate
+
+@Configuration
+class MvProductWeeklyJob(
+    private val jobRepository: JobRepository,
+    private val transactionManager: PlatformTransactionManager,
+    private val productMetricsRepository: ProductMetricsRepository,
+    private val mvProductRankWeeklyRepository: MvProductRankWeeklyRepository,
+) {
+
+    @Bean
+    fun weeklyRankingJob(): Job {
+        return JobBuilder("weeklyRankingJob", jobRepository)
+            .incrementer(RunIdIncrementer())
+            .start(weeklyStep())
+            .build()
+    }
+
+    @Bean
+    fun weeklyStep(): Step {
+        return StepBuilder("weeklyStep", jobRepository)
+            .chunk<ProductMetrics, MvProductRankWeekly>(10, transactionManager)
+            .reader(weeklyProductReader())
+            .processor(weeklyProcessor())
+            .writer(weeklyWriter())
+            .build()
+    }
+
+    @Bean
+    fun weeklyProductReader(): ListItemReader<ProductMetrics> {
+        val today = LocalDate.now()
+        val weekStart = today.minusDays(6)
+
+        val productMetrics = productMetricsRepository.findByMetricDateBetweenOrderByRankAscLimit(weekStart, today, 100)
+
+        return ListItemReader(productMetrics)
+    }
+
+    @Bean
+    fun weeklyProcessor(): ItemProcessor<ProductMetrics, MvProductRankWeekly> = ItemProcessor { productMetrics ->
+        MvProductRankWeekly(
+            productId = productMetrics.productId,
+            productName = productMetrics.productName,
+            brandId = productMetrics.brandId,
+            likeCount = productMetrics.likeCount,
+            rank = productMetrics.rank,
+        )
+    }
+
+    @Bean
+    fun weeklyWriter(): ItemWriter<MvProductRankWeekly> {
+        return ItemWriter { items ->
+            mvProductRankWeeklyRepository.saveAll(items.toList())
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/ProductMetrics.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/ProductMetrics.kt
@@ -1,0 +1,17 @@
+package com.loopers.domain.product
+
+import com.loopers.domain.BaseEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.time.LocalDate
+
+@Entity
+@Table(name = "product_metrics")
+class ProductMetrics(
+    val productId: Long,
+    val productName: String,
+    val brandId: Long,
+    val likeCount: Long,
+    val rank: Long,
+    val metricDate: LocalDate,
+) : BaseEntity()

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/ProductMetricsRepository.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/ProductMetricsRepository.kt
@@ -6,6 +6,6 @@ interface ProductMetricsRepository {
     fun findByMetricDateBetweenOrderByRankAscLimit(
         startDate: LocalDate,
         endDate: LocalDate,
-        limit: Int
+        limit: Long
     ): List<ProductMetrics>
 }

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/ProductMetricsRepository.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/ProductMetricsRepository.kt
@@ -1,0 +1,11 @@
+package com.loopers.domain.product
+
+import java.time.LocalDate
+
+interface ProductMetricsRepository {
+    fun findByMetricDateBetweenOrderByRankAscLimit(
+        startDate: LocalDate,
+        endDate: LocalDate,
+        limit: Int
+    ): List<ProductMetrics>
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankMonthly.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankMonthly.kt
@@ -1,0 +1,15 @@
+package com.loopers.domain.product.mv
+
+import com.loopers.domain.BaseEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "mv_product_rank_monthly")
+class MvProductRankMonthly(
+    val productId: Long,
+    val productName: String,
+    val brandId: Long,
+    val likeCount: Long,
+    val rank: Long,
+) : BaseEntity()

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankMonthlyRepository.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankMonthlyRepository.kt
@@ -1,0 +1,5 @@
+package com.loopers.domain.product.mv
+
+interface MvProductRankMonthlyRepository {
+    fun saveAll(monthlyRanks: List<MvProductRankMonthly>)
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankWeekly.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankWeekly.kt
@@ -1,0 +1,15 @@
+package com.loopers.domain.product.mv
+
+import com.loopers.domain.BaseEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "mv_product_rank_weekly")
+class MvProductRankWeekly(
+    val productId: Long,
+    val productName: String,
+    val brandId: Long,
+    val likeCount: Long,
+    val rank: Long,
+) : BaseEntity()

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankWeeklyRepository.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankWeeklyRepository.kt
@@ -1,0 +1,5 @@
+package com.loopers.domain.product.mv
+
+interface MvProductRankWeeklyRepository {
+    fun saveAll(weeklyRanks: List<MvProductRankWeekly>)
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/product/JpaProductMetricsRepository.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/product/JpaProductMetricsRepository.kt
@@ -1,0 +1,22 @@
+package com.loopers.infrastructure.product
+
+import com.loopers.domain.product.ProductMetrics
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDate
+
+interface JpaProductMetricsRepository : JpaRepository<ProductMetrics, Long> {
+    
+    @Query("""
+        SELECT pm FROM ProductMetrics pm 
+        WHERE pm.metricDate BETWEEN :startDate AND :endDate
+        ORDER BY pm.rank ASC
+        LIMIT :limit
+    """)
+    fun findByMetricDateBetweenOrderByRankAscLimit(
+        @Param("startDate") startDate: LocalDate,
+        @Param("endDate") endDate: LocalDate,
+        @Param("limit") limit: Int
+    ): List<ProductMetrics>
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/product/ProductMetricsRepositoryImpl.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/product/ProductMetricsRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.loopers.infrastructure.product
+
+import com.loopers.domain.product.ProductMetrics
+import com.loopers.domain.product.ProductMetricsRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+class ProductMetricsRepositoryImpl(
+    private val jpaProductMetricsRepository: JpaProductMetricsRepository
+) : ProductMetricsRepository {
+    
+    override fun findByMetricDateBetweenOrderByRankAscLimit(
+        startDate: LocalDate,
+        endDate: LocalDate,
+        limit: Int
+    ): List<ProductMetrics> {
+        return jpaProductMetricsRepository.findByMetricDateBetweenOrderByRankAscLimit(startDate, endDate, limit)
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/product/mv/JpaMvProductRankMonthlyRepository.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/product/mv/JpaMvProductRankMonthlyRepository.kt
@@ -1,0 +1,6 @@
+package com.loopers.infrastructure.product.mv
+
+import com.loopers.domain.product.mv.MvProductRankMonthly
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaMvProductRankMonthlyRepository : JpaRepository<MvProductRankMonthly, Long>

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/product/mv/JpaMvProductRankWeeklyRepository.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/product/mv/JpaMvProductRankWeeklyRepository.kt
@@ -1,0 +1,6 @@
+package com.loopers.infrastructure.product.mv
+
+import com.loopers.domain.product.mv.MvProductRankWeekly
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JpaMvProductRankWeeklyRepository : JpaRepository<MvProductRankWeekly, Long>

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/product/mv/MvProductRankMonthlyRepositoryImpl.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/product/mv/MvProductRankMonthlyRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.loopers.infrastructure.product.mv
+
+import com.loopers.domain.product.mv.MvProductRankMonthly
+import com.loopers.domain.product.mv.MvProductRankMonthlyRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class MvProductRankMonthlyRepositoryImpl(
+    private val jpaMvProductRankMonthlyRepository: JpaMvProductRankMonthlyRepository
+) : MvProductRankMonthlyRepository {
+    
+    override fun saveAll(monthlyRanks: List<MvProductRankMonthly>) {
+        jpaMvProductRankMonthlyRepository.saveAll(monthlyRanks)
+    }
+}

--- a/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/product/mv/MvProductRankWeeklyRepositoryImpl.kt
+++ b/apps/commerce-batch/src/main/kotlin/com/loopers/infrastructure/product/mv/MvProductRankWeeklyRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.loopers.infrastructure.product.mv
+
+import com.loopers.domain.product.mv.MvProductRankWeekly
+import com.loopers.domain.product.mv.MvProductRankWeeklyRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class MvProductRankWeeklyRepositoryImpl(
+    private val jpaMvProductRankWeeklyRepository: JpaMvProductRankWeeklyRepository
+) : MvProductRankWeeklyRepository {
+    
+    override fun saveAll(weeklyRanks: List<MvProductRankWeekly>) {
+        jpaMvProductRankWeeklyRepository.saveAll(weeklyRanks)
+    }
+}

--- a/apps/commerce-batch/src/main/resources/application.yml
+++ b/apps/commerce-batch/src/main/resources/application.yml
@@ -1,0 +1,42 @@
+server:
+  shutdown: graceful
+
+spring:
+  batch:
+    jdbc:
+      initialize-schema: always
+  application:
+    name: commerce-batch
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "loopers-kotlin-spring-template"
 
 include(
     ":apps:commerce-api",
+    ":apps:commerce-batch",
     ":apps:commerce-streamer",
     ":apps:pg-simulator",
     ":modules:jpa",


### PR DESCRIPTION
## 📌 Summary
상품 랭킹 주간/월간 집계 작업 진행했습니다.
배치는 청크로 했지만 조회는 한번에 모두 읽도록 구현했습니다. 일단 요구사항이 top 100 이기 때문에 100 개 정도는 문제 없이 조회할 수 있다고 판단했습니다.

## 💬 Review Points
- 주간/월간 랭킹 조회 시 '오늘' 정보는 랭킹에 반영하기 어려울 것 같은데 보통 당일 정보는 랭킹에 반영하나요? 뭔가 랭킹에 유의미한 차이를 만들지 못할 것 같다는 생각도 듭니다.
- 배치가 오래 걸리는 경우엔 어떻게 처리 하시나요? 이번주에 회사에서 작성한 배치 처리가 데이터가 얼마 없는데도 1분이 넘어가더라고요...
- 배치가 멀티 인스턴스에서 실행되는 경우도 종종 있나요? 만약 그런 경우가 있다면 정합성을 어떻게 보장하는지도 궁금합니다.

## ✅ Checklist
### 🧱 Spring Batch

- [x]  Spring Batch Job 을 작성하고, 파라미터 기반으로 동작시킬 수 있다. ([월간 집계 파라미터](https://github.com/djawnstj/loopers-ecommerce/blob/2fceb38101439f1f87912d47b33e79df2685318a/apps/commerce-batch/src/main/kotlin/com/loopers/application/product/MvProductMonthlyJob.kt#L52), [주간 집계 파라미터](https://github.com/djawnstj/loopers-ecommerce/blob/2fceb38101439f1f87912d47b33e79df2685318a/apps/commerce-batch/src/main/kotlin/com/loopers/application/product/MvProductWeeklyJob.kt#L51))
- [x]  Chunk Oriented Processing (Reader/Processor/Writer or Tasklet) 기반의 배치 처리를 구현했다. ([월간 집계 Step](https://github.com/djawnstj/loopers-ecommerce/blob/2fceb38101439f1f87912d47b33e79df2685318a/apps/commerce-batch/src/main/kotlin/com/loopers/application/product/MvProductMonthlyJob.kt#L41), [주간 집계 Step](https://github.com/djawnstj/loopers-ecommerce/blob/2fceb38101439f1f87912d47b33e79df2685318a/apps/commerce-batch/src/main/kotlin/com/loopers/application/product/MvProductWeeklyJob.kt#L40))
- [x]  집계 결과를 저장할 Materialized View 의 구조를 설계하고 올바르게 적재했다. ([월간 집계 엔티티](https://github.com/djawnstj/loopers-ecommerce/blob/2fceb38101439f1f87912d47b33e79df2685318a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankMonthly.kt#L9), [주간 집계 엔티티](https://github.com/djawnstj/loopers-ecommerce/blob/2fceb38101439f1f87912d47b33e79df2685318a/apps/commerce-batch/src/main/kotlin/com/loopers/domain/product/mv/MvProductRankWeekly.kt#L9))

### 🧩 Ranking API

- [x]  API 가 일간, 주간, 월간 랭킹을 제공하며 조회해야 하는 형태에 따라 적절한 데이터를 기반으로 랭킹을 제공한다. ([랭킹 조회 로직](https://github.com/djawnstj/loopers-ecommerce/blob/2fceb38101439f1f87912d47b33e79df2685318a/apps/commerce-api/src/main/kotlin/com/loopers/application/product/ProductFacade.kt#L35), [랭킹 조회 테스트](https://github.com/djawnstj/loopers-ecommerce/blob/2fceb38101439f1f87912d47b33e79df2685318a/apps/commerce-api/src/test/kotlin/com/loopers/application/product/ProductFacadeIntegrationTest.kt#L249))